### PR TITLE
fix: for a three-letter word in your starting word, and enter it with…

### DIFF
--- a/WordScrambleP5/ViewController.swift
+++ b/WordScrambleP5/ViewController.swift
@@ -64,7 +64,7 @@ class ViewController: UITableViewController {
                 if isPossible(word: lowerAnswer) {
                     if isOriginal(word: lowerAnswer) {
                         if isReal(word: lowerAnswer) {
-                            usedWords.insert(answer, at: 0)
+                            usedWords.insert(lowerAnswer, at: 0)
                             
                             let indexPath = IndexPath(row: 0, section: 0)
                             tableView.insertRows(at: [indexPath], with: .automatic)


### PR DESCRIPTION
… an uppercase letter. Once it appears in the table, try entering it again all lowercase – you’ll see it gets entered